### PR TITLE
bug fix match languages and accessors

### DIFF
--- a/SublimePeek.py
+++ b/SublimePeek.py
@@ -24,7 +24,7 @@ settings = sublime.load_settings(u'SublimePeek.sublime-settings')
 class SublimePeekCommand(sublime_plugin.TextCommand):
     # supported languages and accessors
     languages = ("Python", "Ruby", "Ruby on Rails", "RSpec", "CSS", "HTML", "JavaScript", "PHP", "R", "Stata")
-    accessors = ("python", "python", "identity", "identity", "mapping", "identity", "identity", "mapping")
+    accessors = ("python", "python", "python", "python", "identity", "identity", "mapping", "identity", "identity", "mapping")
     # class variables
     lang = ""
     accessor = ""


### PR DESCRIPTION
The previous commit broke compatibility with R (and some other languages) because languages were added, but the corresponding accessors were not. As a result, there are different #s of languages and accessors. This fixes the problem (making the assumption that the appropriate accessor for RoR and RSpec is `python`).
